### PR TITLE
Expose errors to other crates to enable error chaining.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1280,7 +1280,7 @@ impl ExpressionStatus {
     }
 }
 
-mod errors {
+pub mod errors {
     fn display_exit_status(status: ::std::process::ExitStatus) -> String {
         if cfg!(not(windows)) {
             use std::os::unix::prelude::*;


### PR DESCRIPTION
In order to fully leverage the power of error chain it would be nice to make the error module public. This way, chaining errors is possible from other crates.
I need this functionality for better error handling inside a new tool that depends on duct.rs.

For more information, see https://github.com/brson/error-chain/issues/120