### PR TITLE
Add unix::ExpressionExt containing a uid and gid function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1419,11 +1419,9 @@ fn start_io(
             let inner_handle = expr_inner.0.start(context)?;
             return Ok(HandleInner::Unchecked(Box::new(inner_handle)));
         }
-        #[cfg(unix)]
         Uid(uid) => {
             context.uid = Some(uid);
         }
-        #[cfg(unix)]
         Gid(gid) => {
             context.gid = Some(gid);
         }
@@ -1503,8 +1501,8 @@ enum IoExpressionInner {
     EnvRemove(OsString),
     FullEnv(HashMap<OsString, OsString>),
     Unchecked,
-    #[cfg(unix)] Uid(u32),
-    #[cfg(unix)] Gid(u32),
+    #[cfg_attr(not(unix), allow(dead_code))] Uid(u32),
+    #[cfg_attr(not(unix), allow(dead_code))] Gid(u32),
 }
 
 // An IoContext represents the file descriptors child processes are talking to at execution time.
@@ -1519,8 +1517,8 @@ struct IoContext {
     stderr_capture_pipe: os_pipe::PipeWriter,
     dir: Option<PathBuf>,
     env: HashMap<OsString, OsString>,
-    #[cfg(unix)] uid: Option<u32>,
-    #[cfg(unix)] gid: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
 }
 
 impl IoContext {
@@ -1540,9 +1538,7 @@ impl IoContext {
             stderr_capture_pipe: stderr_capture_pipe,
             dir: None,
             env: env,
-            #[cfg(unix)]
             uid: None,
-            #[cfg(unix)]
             gid: None,
         };
         Ok((context, stdout_reader, stderr_reader))
@@ -1557,9 +1553,7 @@ impl IoContext {
             stderr_capture_pipe: self.stderr_capture_pipe.try_clone()?,
             dir: self.dir.clone(),
             env: self.env.clone(),
-            #[cfg(unix)]
             uid: self.uid.clone(),
-            #[cfg(unix)]
             gid: self.gid.clone(),
         })
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -255,7 +255,9 @@ fn test_multiple_threads() {
     let sleep_cmd = cmd!(path_to_exe("sleep"), "1000000");
     let handle = Arc::new(sleep_cmd.unchecked().start().unwrap());
     let arc_clone = handle.clone();
-    let wait_thread = std::thread::spawn(move || { arc_clone.wait().unwrap(); });
+    let wait_thread = std::thread::spawn(move || {
+        arc_clone.wait().unwrap();
+    });
     handle.kill().unwrap();
     wait_thread.join().unwrap();
 }
@@ -330,9 +332,9 @@ fn test_path() {
         .unwrap()
         .write_all(b"xxx")
         .unwrap();
-    let expr = cmd!(path_to_exe("x_to_y")).stdin(&input_file).stdout(
-        &output_file,
-    );
+    let expr = cmd!(path_to_exe("x_to_y"))
+        .stdin(&input_file)
+        .stdout(&output_file);
     let output = expr.read().unwrap();
     assert_eq!("", output);
     let mut file_output = String::new();

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -2,7 +2,8 @@ extern crate libc;
 
 use std::io;
 
-use super::{Handle, HandleInner, PipeHandle, ThenHandle};
+use super::{Expression, ExpressionInner, Handle, HandleInner, IoExpressionInner, PipeHandle,
+            ThenHandle};
 use shared_child::unix::SharedChildExt;
 
 pub trait HandleExt {
@@ -58,6 +59,26 @@ impl HandleExt for ThenHandle {
     }
 }
 
+pub trait ExpressionExt {
+    fn uid(&self, uid: u32) -> Expression;
+    fn gid(&self, gid: u32) -> Expression;
+}
+
+impl ExpressionExt for Expression {
+    fn uid(&self, uid: u32) -> Expression {
+        Expression::new(ExpressionInner::Io(
+            IoExpressionInner::Uid(uid),
+            self.clone(),
+        ))
+    }
+
+    fn gid(&self, gid: u32) -> Expression {
+        Expression::new(ExpressionInner::Io(
+            IoExpressionInner::Gid(gid),
+            self.clone(),
+        ))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -60,7 +60,42 @@ impl HandleExt for ThenHandle {
 }
 
 pub trait ExpressionExt {
+    /// Sets the child process's user id. This translates to a `setuid` call in the child
+    /// process. Failure in the `setuid` call will cause the spawn to fail.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[macro_use] extern crate duct;
+    /// # #[cfg(unix)] use duct::unix::ExpressionExt;
+    /// # fn main() {
+    /// # if cfg!(unix) {
+    /// let cmd = cmd!("id").uid(123).run();
+    /// let err = cmd.err().unwrap();
+    /// // Changing uid is not allowed unless running as root
+    /// assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    /// # }
+    /// # }
+    /// ```
     fn uid(&self, uid: u32) -> Expression;
+
+    /// Similar to `uid`, but sets the group id of the child process. This has
+    /// the same semantics as the `uid` field.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[macro_use] extern crate duct;
+    /// # #[cfg(unix)] use duct::unix::ExpressionExt;
+    /// # fn main() {
+    /// # if cfg!(unix) {
+    /// let cmd = cmd!("id").gid(123).run();
+    /// let err = cmd.err().unwrap();
+    /// // Changing gid is not allowed unless running as root
+    /// assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    /// # }
+    /// # }
+    /// ```
     fn gid(&self, gid: u32) -> Expression;
 }
 


### PR DESCRIPTION
See #55 for context.

I went ahead and implemented a simple simple support for changing `uid/gid`.

This should not be considered done as it is -- at the very least it's missing documentation and possibly also some tests (I haven't looked at how duct is tested yet). I mostly made it to see how easy it would be to add the functionality and to give us something concrete to discuss.

The main open question is whether to do this as `unix::ExpressionExt` or just add conditional functions on `Expression` itself. I'm leaning towards keeping it as it is, but let me know what you think.

If you like it, I will go ahead an make this a more finished PR.