### PR TITLE
use Vec<OsString> in macro to avoid unnecessary allocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ macro_rules! cmd {
     ( $program:expr $(, $arg:expr )* $(,)? ) => {
         {
             use std::ffi::OsString;
-            let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
+            let args: std::vec::Vec<OsString> = std::vec![$( Into::<OsString>::into($arg) ),*];
             $crate::cmd($program, args)
         }
     };


### PR DESCRIPTION
When `&[OsString]` is converted to `Iterator`, it yields item of type `&OsString` which will be converted to `OsString` again in `duct::cmd`.

Type of `args` in this macro should be `Vec<OsString>` so we avoid `n - 1` additional allocations.

I'm not sure this is worth or not because this code shouldn't be in hot loop anyway.