### PR TITLE
Support optional arguments and sequences in cmd!

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -609,3 +609,20 @@ fn test_pids() -> io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_command_with_iterator() -> io::Result<()> {
+    assert_eq!(
+        cmd!("echo", ...Some("a"), ...["b", "c", "d"]).read()?,
+        "a b c d"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_command_with_trailing_comma() -> io::Result<()> {
+    assert_eq!(cmd!("echo", ...["a"],).read()?, "a");
+
+    Ok(())
+}


### PR DESCRIPTION
This commit allows the `cmd!` macro to also splice in any sequence which implements `IntoIterator<Item: Into<OsString>>`. This requires a bit of extra syntax in the `cmd!` macro since it would be possible for a type to implement both `Into<OsString>` and `IntoIterator`.

So, in order to pass in a sequence to `cmd!` it needs to be prefixed with `...` like this:

```rust
cmd!("echo", "a", ...sequence, "b");
```

I have chosen `...` here because `...<expr>` is not a valid rust expression and so it shouldn't conflict with anything else. Unfortunately, it's not really possible to cleanly create a macro input which declaratively parses either `...$arg` or `$arg` so the `cmd!` macro just takes a bunch of tokens and uses a second helper macro (`cmd_expand_args!`) in order to parse that into something usable.

Since `Option` also implements `IntoIterator` this can also be rather easily used for optional arguments since you can just do:

```rust
cmd!("echo", "a", ...Some("b"));
```

I have tried to expand the docs with some examples to cover all of these use cases which should cover for the actual macro arguments shown in rustdoc being less readable now.

Fixes #88