### PR TITLE
Implement to_string_lossy()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 os_pipe = "1.0.0"
 shared_child = "1.0.0"
 once_cell = "1.0.1"
+shell-words = "1.1.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.43"


### PR DESCRIPTION
Hello,

The attached pull request implements `to_string_lossy()` for Expression to provide a shell command string equivalent for the cmd pipeline (where possible). This should mostly address Issue #79 and Issue #89 and I've gone with the `to_string_lossy()` method name suggested in Issue #89 rather than `implement Display` as I think that this is clearer that this is a lossy conversion. That being said the implementation does its best to capture relatively complex cmd pipelines correctly (including multiple levels of pipe, i/o redirections, manipulating env variables and directory changes - see the embedded docs for examples).

As this relies heavily on UNIX shell syntax it is only enabled for `#[cfg(unix)]`  