### PR TITLE
use case-insensitive strings for env var names on Windows

### DIFF
--- a/src/env_name_str.rs
+++ b/src/env_name_str.rs
@@ -1,0 +1,64 @@
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+use std::hash::{Hash, Hasher};
+
+/// An [`OsString`] that's case-insensitive on Windows, used for environment variable names.
+#[derive(Clone)]
+pub(crate) struct EnvNameString(OsString);
+
+impl Debug for EnvNameString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<OsString> for EnvNameString {
+    fn from(name: OsString) -> Self {
+        EnvNameString(name)
+    }
+}
+
+impl AsRef<OsStr> for EnvNameString {
+    fn as_ref(&self) -> &OsStr {
+        &self.0
+    }
+}
+
+impl PartialEq<Self> for EnvNameString {
+    fn eq(&self, other: &Self) -> bool {
+        // On Windows, env var names are case-insensitive
+        #[cfg(windows)]
+        match (self.0.to_str(), other.0.to_str()) {
+            (Some(s1), Some(s2)) => s1.eq_ignore_ascii_case(s2),
+            // If either name isn't valid Unicode then just leave it as is.
+            _ => self.0 == other.0,
+        }
+
+        // On all other platforms, env var names are case-sensitive.
+        #[cfg(not(windows))]
+        {
+            self.0 == other.0
+        }
+    }
+}
+
+impl Eq for EnvNameString {}
+
+impl Hash for EnvNameString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // On Windows, env var names are case-insensitive
+        #[cfg(windows)]
+        match self.0.to_str() {
+            Some(s) => s.to_ascii_uppercase().hash(state),
+            // If the name isn't valid Unicode then just leave it as is.
+            None => self.0.hash(state),
+        }
+
+        // On all other platforms, env var names are case-sensitive.
+        #[cfg(not(windows))]
+        {
+            self.0.hash(state);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@
 //! # }
 //! ```
 
+use env_name_str::EnvNameString;
 use shared_child::SharedChild;
 use shared_thread::SharedThread;
 use std::collections::HashMap;
@@ -110,6 +111,8 @@ use std::os::windows::prelude::*;
 use std::os::fd::IntoRawFd as IntoRawFdOrHandle;
 #[cfg(windows)]
 use std::os::windows::io::IntoRawHandle as IntoRawFdOrHandle;
+
+mod env_name_str;
 
 /// Unix-specific extensions to duct, for sending signals.
 #[cfg(unix)]
@@ -771,10 +774,7 @@ impl Expression {
         T: Into<OsString>,
         U: Into<OsString>,
     {
-        Self::new(Io(
-            Env(canonicalize_env_var_name(name.into()), val.into()),
-            self.clone(),
-        ))
+        Self::new(Io(Env(name.into().into(), val.into()), self.clone()))
     }
 
     /// Remove a variable from the expression's environment.
@@ -803,10 +803,7 @@ impl Expression {
     where
         T: Into<OsString>,
     {
-        Self::new(Io(
-            EnvRemove(canonicalize_env_var_name(name.into())),
-            self.clone(),
-        ))
+        Self::new(Io(EnvRemove(name.into().into()), self.clone()))
     }
 
     /// Set the expression's entire environment, from a collection of
@@ -841,7 +838,7 @@ impl Expression {
     {
         let env_map = name_vals
             .into_iter()
-            .map(|(k, v)| (canonicalize_env_var_name(k.into()), v.into()))
+            .map(|(k, v)| (k.into().into(), v.into()))
             .collect();
         Self::new(Io(FullEnv(env_map), self.clone()))
     }
@@ -1568,9 +1565,9 @@ enum IoExpressionInner {
     StderrToStdout,
     StdoutStderrSwap,
     Dir(PathBuf),
-    Env(OsString, OsString),
-    EnvRemove(OsString),
-    FullEnv(HashMap<OsString, OsString>),
+    Env(EnvNameString, OsString),
+    EnvRemove(EnvNameString),
+    FullEnv(HashMap<EnvNameString, OsString>),
     Unchecked,
     BeforeSpawn(BeforeSpawnHook),
 }
@@ -1614,7 +1611,7 @@ struct IoContext<'a> {
     stdout_capture: &'a OutputCaptureContext,
     stderr_capture: &'a OutputCaptureContext,
     dir: Option<PathBuf>,
-    env: HashMap<OsString, OsString>,
+    env: HashMap<EnvNameString, OsString>,
     before_spawn_hooks: Vec<BeforeSpawnHook>,
 }
 
@@ -1631,7 +1628,7 @@ impl<'a> IoContext<'a> {
             stdout_capture,
             stderr_capture,
             dir: None,
-            env: std::env::vars_os().collect(),
+            env: std::env::vars_os().map(|(k, v)| (k.into(), v)).collect(),
             before_spawn_hooks: Vec::new(),
         }
     }
@@ -1894,24 +1891,6 @@ impl WaitMode {
             },
         }
     }
-}
-
-#[cfg(windows)]
-fn canonicalize_env_var_name(name: OsString) -> OsString {
-    // On Windows, because env vars are case-insensitive, we uppercase all env
-    // var names. That makes assignments and deletions in our internal map work
-    // the same way they would on the real environment.
-    match name.into_string() {
-        Ok(name) => name.to_uppercase().into(),
-        // If the name isn't valid Unicode then just leave it as is.
-        Err(name) => name,
-    }
-}
-
-#[cfg(not(windows))]
-fn canonicalize_env_var_name(name: OsString) -> OsString {
-    // No-op on all other platforms.
-    name
 }
 
 type ReaderThread = SharedThread<io::Result<Vec<u8>>>;


### PR DESCRIPTION
While using [mise](https://github.com/jdx/mise) on Windows I noticed a bug where the PATH of the spawned command is not set properly, in a random manner (about 50% of the time).

After debugging I found that `duct.rs` doesn't canonicalize existing environment variable names, leading to both `Path` (set by Windows) and `PATH` (set by mise) to be included in the `IoContext.env` HashMap.

Because HashMap entries are randomized in Rust, one of them would take precedence randomly.

This PR switches the canonicalization with case-insensitive strings, which applies to existing env vars too.

I used `to_ascii_uppercase` in the implementation to avoid issues with languages such as Turkish (where uppercase `i` is `İ` and not `I`), and I don't expect non-ascii env vars to be common enough to matter here.

Here's the relevant mise bug report: https://github.com/jdx/mise/discussions/5588

And here's a test binary that triggers this bug:

```rust
use std::path::PathBuf;
use std::str::FromStr;

fn main() -> Result<(), ()> {
    let mut current_path: Vec<_> = std::env::split_paths(&std::env::var_os("PATH").expect("PATH environment variable is not set")).collect();
    current_path.push(PathBuf::from_str("C:/SomePath").unwrap());
    let new_path = std::env::join_paths(&current_path).unwrap();
    let mut passes = 0;
    for _ in 0..50 {
        let cmd = duct::cmd("cmd.exe", &["/c", "set | findstr /B /I path="]).env("PATH", &new_path).stdout_capture();
        let output = cmd.run().unwrap();
        if String::from_utf8_lossy(&output.stdout).contains("SomePath") {
            passes += 1;
        }
    }
    println!("Passed {} / 50 times", passes);
    if passes < 50 {
        Err(())
    } else {
        Ok(())
    }
}
```