### PR TITLE
canonicalize all env var names when we read them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1631,7 +1631,9 @@ impl<'a> IoContext<'a> {
             stdout_capture,
             stderr_capture,
             dir: None,
-            env: std::env::vars_os().collect(),
+            env: std::env::vars_os()
+                .map(|(name, val)| (canonicalize_env_var_name(name), val))
+                .collect(),
             before_spawn_hooks: Vec::new(),
         }
     }
@@ -1902,7 +1904,10 @@ fn canonicalize_env_var_name(name: OsString) -> OsString {
     // var names. That makes assignments and deletions in our internal map work
     // the same way they would on the real environment.
     match name.into_string() {
-        Ok(name) => name.to_uppercase().into(),
+        Ok(mut name) => {
+            name.make_ascii_uppercase();
+            name.into()
+        }
         // If the name isn't valid Unicode then just leave it as is.
         Err(name) => name,
     }


### PR DESCRIPTION
Previously we only canonicalized names added/removed by the caller, but it turns out that the default Windows environment is full of mixed case names, including `Path`.

This was reported by @Wazzaps in https://github.com/oconnor663/duct.rs/pull/119.